### PR TITLE
Use scoped package name in readmes, missing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The Lambda handler extracts the request, runs it through the desired proxy and e
 A basic template for the lambda handler looks something like this:
 
 ```javascript
-//const Proxy = require('lambda-auth-proxy').Local;
+//const Proxy = require('@lastcall/lambda-auth-proxy').Local;
 //const Authorizer = Proxy.authorizer;
 
-const Proxy = require('lambda-auth-proxy').OAuth2;
+const Proxy = require('@lastcall/lambda-auth-proxy').OAuth2;
 const Authorizer = Proxy.authorizers.Github;
 
 let proxy;
@@ -85,7 +85,7 @@ The `Local` proxy uses cookie-based authentication. An HTML form is used to `POS
 #### Example Local Auth Lambda Handler:
 
 ```javascript
-const Proxy = require('lambda-auth-proxy').Local;
+const Proxy = require('@lastcall/lambda-auth-proxy').Local;
 const Authorizer = Proxy.authorizer;
 
 let proxy;
@@ -178,7 +178,7 @@ authorizer.requireOrganizationMembership('LastCallMedia');
 
 ```javascript
 
-const Proxy = require('lambda-auth-proxy').OAuth2;
+const Proxy = require('@lastcall/lambda-auth-proxy').OAuth2;
 const Authorizer = Proxy.authorizers.Github;
 
 let proxy;

--- a/src/oauth2/Proxy.js
+++ b/src/oauth2/Proxy.js
@@ -232,3 +232,11 @@ class Proxy {
 module.exports = Proxy;
 module.exports.authorizers = {};
 module.exports.authorizers.Github = Github;
+
+function parseCookies(headers) {
+    const cookieArr = headers.cookie || []
+
+    return cookieArr.reduce((parsed, cookieObj) => {
+        return Object.assign({}, parsed, cookie.parse(cookieObj.value))
+    }, {})
+}


### PR DESCRIPTION
The readme examples were just using `require('lambda-auth-proxy')...` instead of the new scoped package name `require('@lastcall/lambda-auth-proxy')...`

Also the `parseCookies` function accidentally got lost for the oauth2 proxy when cleaning the package up for npm